### PR TITLE
Add return flag for autorise method

### DIFF
--- a/lib/password-protect/main.js
+++ b/lib/password-protect/main.js
@@ -8,6 +8,9 @@ export const getPasswordProtect = ({ options, ctx, storage }) => {
         if (password === options.password) {
           const token = generateToken(password, options.tokenSeed)
           storage.setCookie(options.cookieName, token)
+          return true
+        } else {
+          return false
         }
       }
     },


### PR DESCRIPTION
Hello, by adding a return flag to the authorize method it's possible to handle warning message for incorrect password without reloading the page. Thank you for the library.