### PR TITLE
Add previousPath param

### DIFF
--- a/lib/password-protect/main.js
+++ b/lib/password-protect/main.js
@@ -42,7 +42,7 @@ export const getPasswordProtect = ({ options, ctx, storage }) => {
 
       const cookieValue = storage.getCookie(options.cookieName)
 
-      if (ctx.route.path === options.formPath) {
+      if (ctx.route.path === options.formPath || (options.ignoredPaths || []).includes(ctx.route.path)) {
         return true
       }
 

--- a/lib/password-protect/main.js
+++ b/lib/password-protect/main.js
@@ -47,7 +47,7 @@ export const getPasswordProtect = ({ options, ctx, storage }) => {
       }
 
       if (!cookieValue || cookieValue !== generateToken(password, options.tokenSeed)) {
-        ctx.redirect(options.formPath)
+        ctx.redirect(options.formPath, { previousPath: ctx.route.fullPath })
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-password-protect",
   "description": "Password protect module for Nuxt.js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "lib/module.js",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Got some feedback that our site didn't redirect them back to the page they originally requested, after the password entry. Couldn't find a cleaner way to preserve the source path, other than appending it to the password form's query params. Thought it might be a worthy feature addition :)