### PR TITLE
feat: Support enabled option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,7 @@ module.exports = {
   modules: ['nuxt-password-protect'],
 
   passwordProtect: {
+    enabled: true,
     formPath: '/password',
     password: 'hello-world',
     tokenSeed: 101010,
@@ -68,6 +69,8 @@ module.exports = {
 ```
 
 With the options you can define the basics of your website protection.
+
+You can also enable or disable the protection using the option `enabled`, this could be a nice way to protect your website depending on the environment is has been deployed too.
 
 ### To protect a page, simply add the middleware
 

--- a/examples/demo/nuxt.config.js
+++ b/examples/demo/nuxt.config.js
@@ -61,6 +61,7 @@ export default {
   },
 
   passwordProtect: {
+    enabled: true,
     formPath: '/password',
     password: 'pass',
     tokenSeed: 3343490,

--- a/lib/password-protect/main.js
+++ b/lib/password-protect/main.js
@@ -31,6 +31,10 @@ export const getPasswordProtect = ({ options, ctx, storage }) => {
     checkUserIfRedirect: () => {
       const password = options.password
 
+      if (options.enabled === false) {
+        return
+      }
+
       if (options.queryString) {
         const queryPassword = ctx.route.query[options.queryString]
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,6 +8,7 @@ Middleware.passwordProtect = Middleware['password-protect'] = function (ctx) {
 }
 
 const defaultOptions = {
+  enabled: true,
   queryString: '_password',
   tokenSeed: 103094582309,
   cookieName: '_password',

--- a/test/getPasswordProtect.test.js
+++ b/test/getPasswordProtect.test.js
@@ -139,6 +139,28 @@ describe('PasswordProtect', () => {
       })
     })
 
+    it('should correctly not redirect the user if the option `enabled` is set to false', () => {
+      const getCookieMock = jest.fn(() => 'something else')
+      const redirectMock = jest.fn()
+
+      const passwordProtectInstance = getPasswordProtect({
+        ctx: {
+          ...baseCtx,
+          redirect: redirectMock
+        },
+        options: {
+          ...options,
+          enabled: false
+        },
+        storage: {
+          getCookie: getCookieMock
+        }
+      })
+
+      passwordProtectInstance.checkUserIfRedirect()
+      expect(redirectMock).not.toBeCalled()
+    })
+
     it('should not redirect the user if authorised', () => {
       const token = generateToken(options.password, options.tokenSeed)
       const getCookieMock = jest.fn(() => token)


### PR DESCRIPTION
Adds support for an option `enabled` to enable or disable the password protection.

The original issue: https://github.com/stephenkr/nuxt-password-protect/issues/22 

Thank you @sergiocastrovale for suggesting it.